### PR TITLE
optional actions for xworld

### DIFF
--- a/games/xworld/xworld_simulator.cpp
+++ b/games/xworld/xworld_simulator.cpp
@@ -154,15 +154,21 @@ int XWorldSimulator::game_over() {
 float XWorldSimulator::take_action(const StatePacket& actions) {
     TeachingEnvironment::take_action(actions);
     last_action_ = "";
-    std::string agent_sent = *(actions.get_buffer("pred_sentence")->get_str());
-    // TODO: Currently assume only one agent for speak action
-    record_agent_sent_in_buffer(agent_sent);
-    last_action_ += "speak(" + agent_sent + ")";
-    // update message box
-    history_messages_.push_back("[Reply] Learner: " + agent_sent);  // add token
-    update_message_box_on_screen();
+
+    if (task_mode_ != "arxiv_lang_acquisition") {
+        CHECK(actions.contain_key("pred_sentence"))
+                << "The agent has to take the speak action.";
+        std::string agent_sent = *(actions.get_buffer("pred_sentence")->get_str());
+        record_agent_sent_in_buffer(agent_sent);
+        last_action_ += "speak(" + agent_sent + ")";
+        // update message box
+        history_messages_.push_back("[Reply] Learner: " + agent_sent);  // add token
+        update_message_box_on_screen();
+    }
 
     if (task_mode_ != "arxiv_interactive") {
+        CHECK(actions.contain_key("action"))
+                << "The agent has to take the move action.";
         int action_idx = *(actions.get_buffer("action")->get_id());
         CHECK_LT(action_idx, get_num_actions());
         // take one step in the game

--- a/games/xworld/xworld_simulator.cpp
+++ b/games/xworld/xworld_simulator.cpp
@@ -155,7 +155,8 @@ float XWorldSimulator::take_action(const StatePacket& actions) {
     TeachingEnvironment::take_action(actions);
     last_action_ = "";
 
-    if (task_mode_ != "arxiv_lang_acquisition") {
+    if (task_mode_ == "arxiv_interactive"
+        || task_mode_ == "arxiv_one_channel") {
         CHECK(actions.contain_key("pred_sentence"))
                 << "The agent has to take the speak action.";
         std::string agent_sent = *(actions.get_buffer("pred_sentence")->get_str());
@@ -166,7 +167,8 @@ float XWorldSimulator::take_action(const StatePacket& actions) {
         update_message_box_on_screen();
     }
 
-    if (task_mode_ != "arxiv_interactive") {
+    if (task_mode_ == "arxiv_lang_acquisition"
+        || task_mode_ == "arxiv_one_channel") {
         CHECK(actions.contain_key("action"))
                 << "The agent has to take the move action.";
         int action_idx = *(actions.get_buffer("action")->get_id());

--- a/python/examples/test_xworld_simulator.py
+++ b/python/examples/test_xworld_simulator.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
         states = xworld.get_state()
         action = compute_action(states, num_actions)
-        r = xworld.take_actions({"action": action, "pred_sentence": "-"})
+        r = xworld.take_actions({"action": action})
         print r
         reward += r
 


### PR DESCRIPTION
The agent can choose to take only one of the two actions depending on the task mode. For "arxiv_lang_acquisition", it only needs to return "action"; for "arxiv_interactive", it only needs to return "pred_sentence"; for "one_channel", it has to return both.