### PR TITLE
add Boost Python dependency to libsimulator.so (for C++ use)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ add_subdirectory(examples)
 ## propagate the dependencies to the upper level (if any)
 target_link_libraries(simulator PUBLIC
   ${DEP_LIBS}
+  ${Boost_LIBRARIES}
   )
 
 set_target_properties(simulator


### PR DESCRIPTION
Before this, we only use Boost Python in py_simulator.so which is not linked by our C++ code. 