### PR TITLE
fix py_gflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,10 @@ set(SIMULATOR_SOURCES
   teaching_task.cpp
   simulator.cpp
   simulator_util.cpp
+  python/py_init.cpp
   )
 
 set(EXTERNAL_LIBS
-  ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
   ${GLOG_LIBRARIES}
   ${GFLAGS_LIBRARIES}
@@ -101,7 +101,6 @@ add_subdirectory(tests)
 add_subdirectory(python)
 add_subdirectory(examples)
 
-## propagate the dependencies to the upper level (if any)
 target_link_libraries(simulator PUBLIC
   ${DEP_LIBS}
   ${Boost_LIBRARIES}

--- a/games/xworld/xworld/xworld.cpp
+++ b/games/xworld/xworld/xworld.cpp
@@ -73,10 +73,7 @@ XWorld::XWorld(const std::string& conf, bool print_conf) {
     std::string item_path = tree->get<std::string>("item_path");
     std::string map = tree->get<std::string>("map");
 
-    // initialize the python interpreter
-    if (!Py_IsInitialized()) {
-        Py_Initialize();
-    }
+    CHECK(Py_IsInitialized());
 
     std::string f = __FILE__;
     std::string path = f.substr(0, f.find_last_of("/") + 1);

--- a/games/xworld/xworld/xworld.h
+++ b/games/xworld/xworld/xworld.h
@@ -31,14 +31,6 @@ class XWorld {
   public:
     XWorld(const std::string& conf, bool print_conf);
 
-    //// Currently boost python does not support Py_Finalize
-    //// http://www.boost.org/doc/libs/1_64_0/libs/python/doc/html/tutorial/tutorial/embedding.html
-    ~XWorld() {
-        //     if (Py_IsInitialized()) {
-        //         Py_Finalize();
-        //     }
-    }
-
     void reset(bool map_reset = true);
 
     // get an image representation of the world

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,14 +7,3 @@ link_simulator_exe(py_simulator) ## link libsimulator to py_simulator
 
 set_target_properties(py_simulator
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-
-add_library(py_gflags
-  SHARED
-  py_gflags.cpp)
-set_target_properties(py_gflags PROPERTIES PREFIX "")  ## remove 'lib' prefix
-
-link_simulator_exe(py_gflags)
-
-set_target_properties(py_gflags
-  PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/python/examples/test_xworld.py
+++ b/python/examples/test_xworld.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         "task_mode": "arxiv_lang_acquisition",
         "context": 1,
         "pause_screen": True,
-        "task_groups_exclusive": True,
+        "task_groups_exclusive": False,
         "ego_centric" : True
     }
     xworld = Simulator.create("xworld", options)

--- a/python/py_simulator.cpp
+++ b/python/py_simulator.cpp
@@ -183,7 +183,6 @@ SimulatorInterface* SimulatorInterface::create_simulator(
 
         auto xwd = std::make_shared<XWorldSimulator>(
             true /*print*/, conf_path);
-
         int agent_id = xwd->add_agent();
         game = std::make_shared<AgentSpecificSimulator>(xwd, agent_id);
         teacher = std::make_shared<Teacher>(conf_path, xwd, false /*print*/);
@@ -198,6 +197,7 @@ SimulatorInterface* SimulatorInterface::create_simulator(
     else {
         throw PyException("Unrecognized game type: " + name);
     }
+
     auto g = new SimulatorInterface(game, teacher);
     g->reset_game();
     return g;

--- a/simulator.h
+++ b/simulator.h
@@ -24,6 +24,12 @@
 #include "simulator_util.h"
 #include "simulator_entity.h"
 
+// This is for compatibility with old version of glog which uses google::
+// Newer versions have resolved this issue
+#ifndef GFLAGS_GFLAGS_H_
+namespace gflags = google;
+#endif
+
 DECLARE_bool(lock_step);
 
 namespace simulator {

--- a/teacher.cpp
+++ b/teacher.cpp
@@ -47,10 +47,7 @@ void Teacher::set_py_task_paths() {
         "./games/xworld/tasks",
     };
 
-    // initialize the python interpreter
-    if (!Py_IsInitialized()) {
-        Py_Initialize();
-    }
+    CHECK(Py_IsInitialized());
 
     std::string f = __FILE__;
     std::string path = f.substr(0, f.find_last_of("/") + 1);

--- a/teacher.h
+++ b/teacher.h
@@ -47,14 +47,6 @@ class Teacher {
             TeachingEnvPtr game,
             bool print_teacher_config = false);
 
-    //// Currently boost python does not support Py_Finalize
-    //// http://www.boost.org/doc/libs/1_64_0/libs/python/doc/html/tutorial/tutorial/embedding.html
-    ~Teacher() {
-        //     if (Py_IsInitialized()) {
-        //         Py_Finalize();
-        //     }
-    }
-
     // reset the teacher's configure file
     // when print=true, print the content of the conf file
     void reset_config(const std::string& teacher_conf, bool print = false);


### PR DESCRIPTION
Originally, we extend embedded python code by importing a boost python module. This will crash. Now I have bypassed boost python and instead directly use Python.h to extend the code.