### PR TITLE
roboschool use opencv to read texture images; clean cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -Wno-deprecated-declara
 include(ExternalProject)
 include(simulator_util)
 
+set(EXTERNAL_PROJECT_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/external")
+
 find_package(Threads REQUIRED)
 find_package(PythonLibs 2.7 EXACT REQUIRED)
 find_package(Boost REQUIRED COMPONENTS python system)

--- a/cmake/opencv.cmake
+++ b/cmake/opencv.cmake
@@ -1,9 +1,11 @@
 message("External project - OpenCV 3.2.0")
 
 ExternalProject_Add(opencv
+  PREFIX ${EXTERNAL_PROJECT_PREFIX}
   GIT_REPOSITORY "https://github.com/opencv/opencv.git"
   GIT_TAG 3.2.0
-  INSTALL_DIR "${CMAKE_SOURCE_DIR}/external/opencv"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opencv"
+  INSTALL_DIR "${EXTERNAL_PROJECT_PREFIX}/opencv"
   LOG_DOWNLOAD ON
   UPDATE_COMMAND ""
   CMAKE_ARGS

--- a/cmake/roboschool.cmake
+++ b/cmake/roboschool.cmake
@@ -73,7 +73,7 @@ ExternalProject_Add(roboschool
   GIT_REPOSITORY "https://github.com/skylian/roboschool"
   GIT_TAG "remove_qt"
   SOURCE_DIR ${ROBOSCHOOL_DIR}
-  DEPENDS assimp bullet glm
+  DEPENDS assimp bullet glm opencv
   LOG_DOWNLOAD ON
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
@@ -81,8 +81,8 @@ ExternalProject_Add(roboschool
 )
 
 ## make roboschool
-set(ROBOSCHOOL_INCLUDE_DEPS ${ASSIMP_INCLUDE_PATH} ${GLM_INCLUDE_PATH} ${BULLET_INCLUDE_PATHS})
-set(ROBOSCHOOL_LIB_DEPS ${ASSIMP_LIBRARIES} ${BULLET_LIBRARIES})
+set(ROBOSCHOOL_INCLUDE_DEPS ${ASSIMP_INCLUDE_PATH} ${GLM_INCLUDE_PATH} ${BULLET_INCLUDE_PATHS} ${OPENCV_INCLUDE_PATH})
+set(ROBOSCHOOL_LIB_DEPS ${ASSIMP_LIBRARIES} ${BULLET_LIBRARIES} ${OPENCV_LIBS})
 
 ## custom make
 add_custom_command(TARGET roboschool POST_BUILD

--- a/cmake/roboschool.cmake
+++ b/cmake/roboschool.cmake
@@ -12,9 +12,11 @@ endfunction(append_libraries)
 
 ## assimp
 ExternalProject_Add(assimp
+  PREFIX ${EXTERNAL_PROJECT_PREFIX}
   GIT_REPOSITORY "https://github.com/yu239/assimp"
   GIT_TAG "master"
-  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/assimp"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/assimp"
+  INSTALL_DIR "${EXTERNAL_PROJECT_PREFIX}/assimp"
   LOG_DOWNLOAD ON
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -26,9 +28,11 @@ set(ASSIMP_LIBRARIES "${INSTALL_DIR}/lib/libassimp.so.4")
 
 # glm
 ExternalProject_Add(glm
+  PREFIX ${EXTERNAL_PROJECT_PREFIX}
   GIT_REPOSITORY "https://github.com/g-truc/glm.git"
   GIT_TAG "0.9.8.4"
-  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/glm"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/glm"
+  INSTALL_DIR "${EXTERNAL_PROJECT_PREFIX}/glm"
   LOG_DOWNLOAD ON
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -39,9 +43,11 @@ set(GLM_INCLUDE_PATH "${INSTALL_DIR}/include")
 
 ## bullet physics
 ExternalProject_Add(bullet
+  PREFIX ${EXTERNAL_PROJECT_PREFIX}
   GIT_REPOSITORY "https://github.com/skylian/bullet3"
   GIT_TAG "master"
-  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/bullet"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/bullet"
+  INSTALL_DIR "${EXTERNAL_PROJECT_PREFIX}/bullet"
   LOG_DOWNLOAD ON
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -66,13 +72,13 @@ set(BULLET_LIBRARIES
   "${INSTALL_DIR}/lib/libBulletInverseDynamics.so"
   "${INSTALL_DIR}/lib/libPhysicsClientC_API.so")
 
-set(ROBOSCHOOL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/roboschool)
-
 ## roboschool
 ExternalProject_Add(roboschool
+  PREFIX ${EXTERNAL_PROJECT_PREFIX}
   GIT_REPOSITORY "https://github.com/skylian/roboschool"
   GIT_TAG "remove_qt"
-  SOURCE_DIR ${ROBOSCHOOL_DIR}
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/roboschool"
+  INSTALL_DIR "${EXTERNAL_PROJECT_PREFIX}/roboschool"
   DEPENDS assimp bullet glm opencv
   LOG_DOWNLOAD ON
   BUILD_COMMAND ""
@@ -80,8 +86,10 @@ ExternalProject_Add(roboschool
   CONFIGURE_COMMAND ""
 )
 
+ExternalProject_Get_Property(roboschool SOURCE_DIR)
+set(ROBOSCHOOL_DIR ${SOURCE_DIR})
 ## make roboschool
-set(ROBOSCHOOL_INCLUDE_DEPS ${ASSIMP_INCLUDE_PATH} ${GLM_INCLUDE_PATH} ${BULLET_INCLUDE_PATHS} ${OPENCV_INCLUDE_PATH})
+set(ROBOSCHOOL_INCLUDE_DEPS ${ASSIMP_INCLUDE_PATH} ${GLM_INCLUDE_PATH} ${BULLET_INCLUDE_PATHS} ${OpenCV_INCLUDE_DIRS})
 set(ROBOSCHOOL_LIB_DEPS ${ASSIMP_LIBRARIES} ${BULLET_LIBRARIES} ${OPENCV_LIBS})
 
 ## custom make

--- a/games/xworld3d/tasks/xworld3d_task.py
+++ b/games/xworld3d/tasks/xworld3d_task.py
@@ -283,6 +283,7 @@ class XWorld3DTask(object):
 
         def reach_object(agent, yaw, object):
             theta, _, _ = self._get_direction_and_distance(agent, object.loc, yaw)
+
             return abs(theta) < self.orientation_threshold and object.id in collisions
 
         def successful_goal(reward):


### PR DESCRIPTION
1) roboschool uses OpenCV, which is the first step to merge roboschool into xworld3d
2) clean cmake to make folder structures more consistent
