### PR TITLE
make_screen should appear after the teaching stage

### DIFF
--- a/simulator.cpp
+++ b/simulator.cpp
@@ -103,7 +103,6 @@ float GameSimulator::take_actions(const StatePacket& actions, int actrep, bool s
         }
         reward += take_action(actions);
     }
-    make_context_screens();
     return reward;
 }
 
@@ -114,7 +113,6 @@ void GameSimulator::init_screen() {
 
 void GameSimulator::reset_game() {
     num_steps_ = 0;
-    init_screen();
 }
 
 std::string GameSimulator::get_screen_name() {

--- a/simulator.h
+++ b/simulator.h
@@ -168,6 +168,17 @@ class GameSimulator {
 
     static std::string decode_game_over_code(int code);
 
+    /**
+     * @brief clear screens_ and initialize it using current screen.
+     */
+    void init_screen();
+
+    /**
+     * @brief update screens_ by adding current screen at the beginning and
+     * remove the oldest screen
+     */
+    void make_context_screens();
+
   protected:
     int64_t num_steps_;  // number of steps since the beginning of the game
 
@@ -189,20 +200,9 @@ class GameSimulator {
     std::string get_screen_name();
 
     /**
-     * @brief clear screens_ and initialize it using current screen.
-     */
-    void init_screen();
-
-    /**
      * @brief allocate space for screens_
      */
     void init_context_screens(bool is_uint8);
-
-    /**
-     * @brief update screens_ by adding current screen at the beginning and
-     * remove the oldest screen
-     */
-    void make_context_screens();
 
     /**
      * @brief Shift the context by one screen of size screen_sz to right.

--- a/simulator_interface.cpp
+++ b/simulator_interface.cpp
@@ -96,6 +96,7 @@ void SimulatorInterface::reset_game() {
         teacher_->reset_after_game_reset();
         teacher_->teach();
     }
+    game_->init_screen();
 }
 
 std::string SimulatorInterface::game_over_string() {
@@ -125,6 +126,7 @@ float SimulatorInterface::take_actions(const StatePacket& actions, int act_rep, 
                             // reward
         r += teacher_->give_reward();
     }
+    game_->make_context_screens();
     acc_reward_ += r;
     return r;
 }


### PR DESCRIPTION
The teacher could change the env at a time step. To avoid a time delay, we should make_screen only after the teaching stage.