### PR TITLE
Allow setting FLAGS_color from python interface

### DIFF
--- a/confs/walls3d.json
+++ b/confs/walls3d.json
@@ -6,7 +6,7 @@
             "held_out" : [
             ],
             "weight" : 0.5,
-            "schedule" : "random",  // optional, default "random"
+            "schedule" : "random",
             "tasks" : {
                 "XWorld3DNavTarget" : 1
             }

--- a/python/examples/test_xworld3d.py
+++ b/python/examples/test_xworld3d.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         game_over_str = x3d.game_over()
         states = x3d.get_state()
         action = compute_action(states, num_actions)
-        r = x3d.take_actions({"action": action, "pred_sentence" : ""}, 1, False)
+        r = x3d.take_actions({"action": action, "pred_sentence" : ""}, 1, True)
 
         if game_over_str != "alive":
             print "game over because of ", game_over_str

--- a/python/py_simulator.cpp
+++ b/python/py_simulator.cpp
@@ -130,6 +130,7 @@ void init_xworld_gflags(const py::dict& args) {
             extract_py_dict_val(args, "task_groups_exclusive", false, true);
     FLAGS_context = extract_py_dict_val(args, "context", false, 1);
     FLAGS_visible_radius = extract_py_dict_val(args, "visible_radius", false, 0);
+    FLAGS_color = extract_py_dict_val(args, "color", false, false);
 }
 
 ///////////////////// pass flags in python dict to GFlags ///////////////////
@@ -146,6 +147,7 @@ void init_xworld3d_gflags(const py::dict& args) {
     FLAGS_x3_move_speed = extract_py_dict_val(args, "x3_move_speed", false, 25.0f);
     FLAGS_x3_turning_rad = extract_py_dict_val(args, "x3_turning_rad", false, M_PI / 8);
     FLAGS_x3_big_screen = extract_py_dict_val(args, "x3_big_screen", false, false);
+    FLAGS_color = extract_py_dict_val(args, "color", false, false);
 #endif
 }
 
@@ -317,7 +319,7 @@ BOOST_PYTHON_MODULE(py_simulator) {
         // intentionally bind take_actions to two functions so that it has
         // optional args
         .def("take_actions", &PySimulatorInterface::take_actions)
-        .def("take_actions", &PySimulatorInterface::take_action)
+        .def("take_action", &PySimulatorInterface::take_action)
         .def("get_state", &PySimulatorInterface::get_state)
         .def("get_num_steps", &PySimulatorInterface::get_num_steps);
 }

--- a/simulator_interface.cpp
+++ b/simulator_interface.cpp
@@ -43,7 +43,6 @@ SimulatorInterface::SimulatorInterface(const std::string& name, bool server)
         } else if (name == "simple_race") {
             game_ = std::make_shared<SimpleRaceGame>();
         } else if (name == "xworld") {
-            FLAGS_color = true;
             if (FLAGS_task_mode == "arxiv_lang_acquisition") {
                 FLAGS_task_groups_exclusive = false;
             }


### PR DESCRIPTION
Also the following:
1. fixed overloading of take_actions in py_simulator
2. remove "//" from walls.json because it cannot parsed by some boost version