### PR TITLE
Fix a bug in removing unfound entities in xworld3d

### DIFF
--- a/games/xworld3d/xworld3d.cpp
+++ b/games/xworld3d/xworld3d.cpp
@@ -228,7 +228,6 @@ void X3World::update_world(const std::vector<Entity>& entities) {
             remove_item(i.second);
         }
     }
-    items_ = tmp;
 
     for (auto const& e : entities) {
         if (items_.find(e.id) != items_.end()) {


### PR DESCRIPTION
This bug could lead to incorrect results if there is within session entity deleting.