### PR TITLE
show the current command on top of the video for demo purpose

### DIFF
--- a/games/xworld/xworld_simulator.cpp
+++ b/games/xworld/xworld_simulator.cpp
@@ -295,6 +295,28 @@ cv::Mat XWorldSimulator::concat_images(cv::Mat img1,
     return img_concat;
 }
 
+cv::Mat XWorldSimulator::get_command_image(const std::string& cmd) {
+    cv::Mat canvas(50, 500, CV_8UC3, cv::Scalar(0, 0, 0));
+    auto content = cmd.substr(cmd.find("]") + 1); // remove task type
+    cv::putText(canvas,
+                content.substr(0, content.find(":") + 1),
+                cv::Point(10, 20),
+                cv::FONT_HERSHEY_SIMPLEX,
+                0.5,
+                cv::Scalar(150, 150, 150),
+                1,
+                CV_AA);
+    cv::putText(canvas,
+                content.substr(content.find(":") + 1),
+                cv::Point(10, 40),
+                cv::FONT_HERSHEY_SIMPLEX,
+                0.4,
+                cv::Scalar(255, 255, 255),
+                1,
+                CV_AA);
+    return canvas;
+}
+
 cv::Mat XWorldSimulator::get_reward_image(float reward) {
     cv::Mat canvas(200, 200, CV_8UC3, cv::Scalar(0, 0, 0));
     std::stringstream stream;
@@ -412,7 +434,11 @@ void XWorldSimulator::show_screen(float reward) {
     cv::Mat img = xworld_.to_image(active_agent_id_,
                                    /*flag_illustration=*/ true,
                                    FLAGS_visible_radius);
-    cv::Mat img_wo_msg = concat_images(img, get_reward_image(reward), true);
+    cv::Mat command_img = get_command_image(history_messages_.back());
+    cv::Mat img_wo_msg = concat_images(command_img,
+                                       concat_images(img, get_reward_image(reward), true),
+                                       true);
+
     prev_screen_ = img_wo_msg;
     screen_ = concat_images(img_wo_msg, get_message_image(history_messages_), false);
 

--- a/games/xworld/xworld_simulator.h
+++ b/games/xworld/xworld_simulator.h
@@ -98,6 +98,8 @@ class XWorldSimulator : public GameSimulatorMulti, public TeachingEnvironment {
     void update_message_box_on_screen();  // reward msg box on the screen with
                                           // updated msgs
 
+    cv::Mat get_command_image(const std::string& cmd);
+
     cv::Mat get_reward_image(float reward);  // get the sub-image for reward
 
     cv::Mat get_message_image(

--- a/games/xworld3d/confs/navigation.json
+++ b/games/xworld3d/confs/navigation.json
@@ -9,9 +9,7 @@
             "schedule" : "random",
             "tasks" : {
                 "XWorld3DNavTarget" : 1,
-                "XWorld3DNavTargetNear" : 1,
-                "XWorld3DNavTargetSide" : 1,
-                "XWorld3DNavTargetBetween" : 1
+                "XWorld3DNavTargetNear" : 1
             }
         }
     }

--- a/games/xworld3d/xworld3d_flags.cpp
+++ b/games/xworld3d/xworld3d_flags.cpp
@@ -36,5 +36,5 @@ DEFINE_double(x3_time_step, 0.0066, "time step for one simulation step");
 //DEFINE_int32(x3_frame_skip, 1, "time step for one simulation step");
 DEFINE_string(
     x3_task_mode,
-    "one_channel",
+    "arxiv_lang_acquisition",
     "arxiv_lang_acquisition|arxiv_interactive|one_channel");

--- a/games/xworld3d/xworld3d_simulator.cpp
+++ b/games/xworld3d/xworld3d_simulator.cpp
@@ -195,8 +195,12 @@ void X3Simulator::show_screen(float reward) {
     cv::Mat img;
     impl_->get_screen_rgb(active_agent_id_, img, bird_view_);
 
+    cv::Mat command_img = get_command_image(history_messages_.back());
     cv::Mat reward_img = get_reward_image(reward);
-    cv::Mat img_wo_msg = concat_images(img, reward_img, true);
+    cv::Mat img_wo_msg = concat_images(command_img,
+                                       concat_images(img, reward_img, true),
+                                       true);
+
     prev_screen_ = img_wo_msg;
     screen_ = concat_images(img_wo_msg,
                             get_message_image(history_messages_),
@@ -408,6 +412,28 @@ void X3Simulator::get_screen(StatePacket& screen) {
                           FLAGS_color);
     screen = StatePacket();
     screen.add_buffer_value("screen", screen_vec);
+}
+
+cv::Mat X3Simulator::get_command_image(const std::string& cmd) {
+    cv::Mat canvas(50, 500, CV_8UC3, cv::Scalar(0, 0, 0));
+    auto content = cmd.substr(cmd.find("]") + 1); // remove task type
+    cv::putText(canvas,
+                content.substr(0, content.find(":") + 1),
+                cv::Point(10, 20),
+                cv::FONT_HERSHEY_SIMPLEX,
+                0.5,
+                cv::Scalar(150, 150, 150),
+                1,
+                CV_AA);
+    cv::putText(canvas,
+                content.substr(content.find(":") + 1),
+                cv::Point(10, 40),
+                cv::FONT_HERSHEY_SIMPLEX,
+                0.4,
+                cv::Scalar(255, 255, 255),
+                1,
+                CV_AA);
+    return canvas;
 }
 
 cv::Mat X3Simulator::get_reward_image(float reward) {

--- a/games/xworld3d/xworld3d_simulator.h
+++ b/games/xworld3d/xworld3d_simulator.h
@@ -84,6 +84,8 @@ private:
 
     void record_collision_events(const std::set<std::string>& collision_list);
 
+    cv::Mat get_command_image(const std::string& cmd);
+
     cv::Mat get_reward_image(float reward);  // get the sub-image for reward
 
     cv::Mat get_message_image(


### PR DESCRIPTION
When creating the demo, we should crop the region with the actual width of the image, excluding the right message box.