### PR TITLE
fixed the window name bug so that there won't be two duplicated windows when update_message_box_on_screen() is called

### DIFF
--- a/games/xworld/xworld_simulator.cpp
+++ b/games/xworld/xworld_simulator.cpp
@@ -426,7 +426,7 @@ void XWorldSimulator::update_message_box_on_screen() {
         cv::Mat img_all = concat_images(
             prev_screen_, get_message_image(history_messages_), false);
         cv::waitKey(1);
-        cv::imshow("XWorld Game", img_all);
+        cv::imshow("XWorld2D", img_all);
     }
 }
 

--- a/games/xworld3d/maps/XWorld3DDialogMap.py
+++ b/games/xworld3d/maps/XWorld3DDialogMap.py
@@ -75,4 +75,4 @@ class XWorld3DDialogMap(XWorld3DEnv):
         # re-instantiate within the same session
         # re-load from map config with the same set of sampled classes
         for e in self.get_goals():
-            self.set_property(e, property_value_dict={"asset_path" : None, "yaw" : None, "id" : 1})
+            self.set_property(e, property_value_dict={"asset_path" : None, "yaw" : None})


### PR DESCRIPTION
1) fixed the window name bug so that there won't be two duplicated windows
2) also changed the 3DDialogMap config in accordance to the changed set_property function