### PR TITLE
add dry run (running w/o opengl init) function to xworld3d

### DIFF
--- a/games/xworld3d/xworld3d.cpp
+++ b/games/xworld3d/xworld3d.cpp
@@ -162,7 +162,7 @@ X3World::~X3World() {
 }
 
 void X3World::reset_world(bool map_reset) {
-    assert(world_);
+    CHECK(world_) << "reset_world cannot be called during dry run.";
     std::vector<Entity> entities;
     try {
         if (map_reset) {
@@ -212,7 +212,7 @@ void X3World::clear_world() {
 }
 
 void X3World::update_world(const std::vector<Entity>& entities) {
-    assert(world_);
+    CHECK(world_) << "update_world cannot be called during dry run.";
     stadium_.load_stadium(item_path_, world_);
 
     auto found_item_in_entities = [&](const std::string& id)->bool {
@@ -251,7 +251,7 @@ void X3World::update_world(const std::vector<Entity>& entities) {
 }
 
 void X3World::add_item(const Entity& e) {
-    assert(world_);
+    CHECK(world_) << "add_item cannot be called during dry run.";
     CHECK(items_.find(e.id) == items_.end())
             << e.type << " " << e.id << " exists.";
 
@@ -334,13 +334,13 @@ void X3World::remove_item(X3ItemPtr& item) {
 }
 
 roboschool::RenderResult X3World::render(const size_t agent_id, bool debug) {
-    assert(world_);
+    CHECK(world_) << "render cannot be called during dry run.";
     auto agent_ptr = get_agent(agent_id);
     return camera_->render(agent_ptr.get(), debug);
 }
 
 void X3World::step(const int frame_skip) {
-    assert(world_);
+    CHECK(world_) << "step cannot be called during dry run.";
     world_->step(frame_skip);
     for (auto& i : items_) {
         i.second->sync_entity_info();

--- a/games/xworld3d/xworld3d.h
+++ b/games/xworld3d/xworld3d.h
@@ -97,7 +97,7 @@ private:
 
 class X3World {
 public:
-    X3World(const std::string& conf, bool print_conf, bool big_screen);
+    X3World(const std::string& conf, bool print_conf, bool dry_run, bool big_screen);
 
     X3World(const X3World&)  = delete;
 

--- a/games/xworld3d/xworld3d_flags.cpp
+++ b/games/xworld3d/xworld3d_flags.cpp
@@ -38,3 +38,4 @@ DEFINE_string(
     x3_task_mode,
     "lang_acquisition",
     "lang_acquisition|interactive|one_channel");
+DEFINE_bool(x3_dry_run, false, "true if it is just a dry run (no opengl init)");

--- a/games/xworld3d/xworld3d_flags.h
+++ b/games/xworld3d/xworld3d_flags.h
@@ -29,3 +29,4 @@ DECLARE_double(x3_time_step);
 //DECLARE_int32(x3_frame_skip);
 DECLARE_string(x3_task_mode);
 DECLARE_bool(x3_big_screen);
+DECLARE_bool(x3_dry_run);

--- a/games/xworld3d/xworld3d_simulator.cpp
+++ b/games/xworld3d/xworld3d_simulator.cpp
@@ -147,10 +147,9 @@ X3Simulator::X3Simulator(bool print, bool big_screen) :
         bird_view_(false),
         agent_received_sentences_(0),
         agent_prev_actions_(0),
-        keyboard_action_(-1),
-        dry_run_(FLAGS_x3_dry_run) {
+        keyboard_action_(-1) {
     impl_ = util::make_unique<X3SimulatorImpl>(
-            FLAGS_x3_conf, print, dry_run_, big_screen);
+            FLAGS_x3_conf, print, FLAGS_x3_dry_run, big_screen);
 }
 
 X3Simulator::~X3Simulator() {}

--- a/games/xworld3d/xworld3d_simulator.cpp
+++ b/games/xworld3d/xworld3d_simulator.cpp
@@ -26,7 +26,7 @@ namespace xworld3d {
 */
 class X3SimulatorImpl {
 public:
-    X3SimulatorImpl(const std::string& conf, bool print, bool big_screen = false);
+    X3SimulatorImpl(const std::string& conf, bool print, bool dry_run, bool big_screen = false);
 
     ~X3SimulatorImpl() {}
 
@@ -69,8 +69,9 @@ private:
 
 X3SimulatorImpl::X3SimulatorImpl(const std::string& conf,
                                  bool print,
+                                 bool dry_run,
                                  bool big_screen) :
-        xworld3d_(conf, print, big_screen),
+        xworld3d_(conf, print, dry_run, big_screen),
         height_(0), width_(0) {}
 
 void X3SimulatorImpl::reset_game(bool map_reset) {
@@ -146,9 +147,10 @@ X3Simulator::X3Simulator(bool print, bool big_screen) :
         bird_view_(false),
         agent_received_sentences_(0),
         agent_prev_actions_(0),
-        keyboard_action_(-1) {
+        keyboard_action_(-1),
+        dry_run_(FLAGS_x3_dry_run) {
     impl_ = util::make_unique<X3SimulatorImpl>(
-            FLAGS_x3_conf, print, big_screen);
+            FLAGS_x3_conf, print, dry_run_, big_screen);
 }
 
 X3Simulator::~X3Simulator() {}

--- a/games/xworld3d/xworld3d_simulator.h
+++ b/games/xworld3d/xworld3d_simulator.h
@@ -124,7 +124,6 @@ private:
         history_messages_;  // history message buffer for showing in the GUI
     std::string game_events_;
     int keyboard_action_;
-    bool dry_run_;
 };
 
 }} // simulator::xworld3d

--- a/games/xworld3d/xworld3d_simulator.h
+++ b/games/xworld3d/xworld3d_simulator.h
@@ -124,6 +124,7 @@ private:
         history_messages_;  // history message buffer for showing in the GUI
     std::string game_events_;
     int keyboard_action_;
+    bool dry_run_;
 };
 
 }} // simulator::xworld3d

--- a/python/py_simulator.cpp
+++ b/python/py_simulator.cpp
@@ -149,6 +149,7 @@ void init_xworld3d_gflags(const py::dict& args) {
     FLAGS_x3_move_speed = extract_py_dict_val(args, "x3_move_speed", false, 25.0f);
     FLAGS_x3_turning_rad = extract_py_dict_val(args, "x3_turning_rad", false, M_PI / 8);
     FLAGS_x3_big_screen = extract_py_dict_val(args, "x3_big_screen", false, false);
+    FLAGS_x3_dry_run = extract_py_dict_val(args, "x3_dry_run", false, false);
     FLAGS_color = extract_py_dict_val(args, "color", false, false);
 #endif
 }


### PR DESCRIPTION
This function is used to get environment information without actually creating OpenGL context.